### PR TITLE
feat: add changeCommunityCurrency endpoint + Community.currency (SAT-5262)

### DIFF
--- a/api/community.ts
+++ b/api/community.ts
@@ -887,6 +887,42 @@ async (args: UpdateCommunityArgs) => {
     return handleResponse<Community>(response);
 };
 
+export type ChangeCommunityCurrencyArgs = {
+    communityId: number;
+    currency: OrderCurrency;
+};
+
+// Changes a community's currency. The backend converts all paid tier amounts from the
+// old currency to the new one at the current exchange rate. Rejected with 403 once a
+// paid membership transaction exists for the community (currency is then locked).
+// Returns an empty object on success (204).
+export const changeCommunityCurrency = (
+    urlArg: URL,
+    getJwt: func_GetJwt,
+) =>
+async (args: ChangeCommunityCurrencyArgs) => {
+    const jwtToken = getJwt();
+    if (jwtToken == "") {
+        return new Error("jwt token is empty");
+    }
+    const url = copyURL(urlArg);
+    url.pathname = `/secure/communities/${args.communityId}/currency`;
+
+    const headers = new Headers();
+    headers.set("Authorization", `Bearer ${jwtToken}`);
+    headers.set("Content-Type", "application/json");
+
+    const response = await safeFetch(url, {
+        method: "PUT",
+        headers,
+        body: JSON.stringify({ currency: args.currency }),
+    });
+    if (response instanceof Error) {
+        return response;
+    }
+    return handleResponse<Record<string, never>>(response);
+};
+
 export type MembershipTierPayload = {
     name: string;
     description?: string;

--- a/models/community.ts
+++ b/models/community.ts
@@ -26,6 +26,9 @@ export type Community = {
     sampleMembers: SearchAccountDTO[]; // a sample top-N subset (ranked by follower count)
     logo?: string;
     whopId?: string;
+    // Community-level currency (USD default). Source of truth for all paid tier pricing;
+    // tiers no longer store their own currency. Changed via changeCommunityCurrency.
+    currency?: OrderCurrency | null;
 };
 
 export type CommunityTheme = {

--- a/sdk.ts
+++ b/sdk.ts
@@ -376,6 +376,7 @@ import {
     addMembersToCommunity,
     addProspectsToCommunity,
     cancelCommunityMembershipRequest,
+    changeCommunityCurrency,
     createCommunity,
     createCommunityFromCalendar,
     createCommunityMembershipTier,
@@ -911,6 +912,7 @@ export class Client {
     // Community
     createCommunity: ReturnType<typeof createCommunity>;
     updateCommunity: ReturnType<typeof updateCommunity>;
+    changeCommunityCurrency: ReturnType<typeof changeCommunityCurrency>;
     deleteCommunity: ReturnType<typeof deleteCommunity>;
     searchCommunities: ReturnType<typeof searchCommunities>;
     createCommunityFromCalendar: ReturnType<
@@ -1580,6 +1582,7 @@ export class Client {
         // Community
         this.createCommunity = createCommunity(rest_api_url, getJwt);
         this.updateCommunity = updateCommunity(rest_api_url, getJwt);
+        this.changeCommunityCurrency = changeCommunityCurrency(rest_api_url, getJwt);
         this.deleteCommunity = deleteCommunity(rest_api_url, getJwt);
         this.searchCommunities = searchCommunities(rest_api_url, getJwt);
         this.createCommunityFromCalendar = createCommunityFromCalendar(


### PR DESCRIPTION
## Summary
Adds community-level currency support: `changeCommunityCurrency` wrapping `PUT /secure/communities/{id}/currency` (204 on success; 403 once the currency is locked by a paid transaction), and a `currency` field on the `Community` model. Backend (SAT-5273) converts paid tier amounts on change.

## Linear
https://linear.app/sat-lantis/issue/SAT-5262