### PR TITLE
chore: add NZD to OrderCurrency enum (SAT-5276)

### DIFF
--- a/models/ticketing.ts
+++ b/models/ticketing.ts
@@ -9,6 +9,7 @@ export enum OrderCurrency {
     CAD = "CAD",
     GBP = "GBP",
     AUD = "AUD",
+    NZD = "NZD",
 }
 
 export enum CouponDiscountType {


### PR DESCRIPTION
Allows New Zealand Dollar (NZD) as a fiat option alongside USD/EUR/CAD/AUD/GBP.